### PR TITLE
Feature/api endpoint cities

### DIFF
--- a/app/api/companies.py
+++ b/app/api/companies.py
@@ -37,7 +37,6 @@ def get_cities():
 
     # Get the parameters from request
     param_dict = request.args.to_dict()
-    # city_like = request.args.get('city_like')
 
     # Check if city_like parameter is in GET request
     if 'city_like' in param_dict:
@@ -45,15 +44,14 @@ def get_cities():
 
         # Raw SQL query to get a selection of cities which fit the city_like parameter
         query = db.session.execute(
-            "SELECT cities.city_name, COUNT(cities.city_id) AS city_count FROM COMPANIES JOIN CITIES ON companies.city_id=cities.city_id WHERE lower(cities.city_name) LIKE lower(:city_like) GROUP BY companies.city_id, cities.city_name", {"city_like": city_like})
+            "SELECT cities.city_name, COUNT(cities.city_id) AS city_count FROM COMPANIES JOIN CITIES ON companies.city_id=cities.city_id WHERE lower(cities.city_name) LIKE lower(:city_like) GROUP BY companies.city_id, cities.city_name ORDER BY city_count DESC", {"city_like": city_like})
     else:
         # Raw SQL query to get all cities with company count
         query = db.session.execute(
-            "SELECT cities.city_name, COUNT(cities.city_id) AS city_count FROM COMPANIES JOIN CITIES ON companies.city_id=cities.city_id GROUP BY companies.city_id, cities.city_name")
+            "SELECT cities.city_name, COUNT(cities.city_id) AS city_count FROM COMPANIES JOIN CITIES ON companies.city_id=cities.city_id GROUP BY companies.city_id, cities.city_name ORDER BY city_count DESC")
 
-    # Returns a list with a list for every city
-    city_dict = dict((x, y) for x, y in query.fetchall())
-    sorted_list = sorted(city_dict.items(), key=lambda x: x[1], reverse=True)
+    # Put the query results in a sorted list
+    sorted_list = list((x, y) for x, y in query.fetchall())
 
     return jsonify(sorted_list)
 

--- a/tests/functional/test_get_cities.py
+++ b/tests/functional/test_get_cities.py
@@ -27,3 +27,5 @@ def test_get_cities_city_like(client, init_testdb, insert_data_db):
 
     assert response.status_code == 200
     assert len(data) == 2
+    assert isinstance(data['Amsterdam'], int)
+    assert isinstance(data['Rotterdam'], int)

--- a/tests/functional/test_get_cities.py
+++ b/tests/functional/test_get_cities.py
@@ -1,11 +1,11 @@
 from flask import json
 
 
-def test_get_cities(client, init_testdb, insert_data_db):
+def test_get_cities(client, insert_data_db):
     '''
-    GIVEN that there are more than 15 companies in the DB
+    GIVEN that there are mutiple cities in the DB
     WHEN the '/api/v1/cities' page is requested (GET)
-    THEN the response will contain a dict of all the city records (key) and the count (value) of companies in those cities
+    THEN the response will contain a list of all the cities and the count of companies in those cities
     '''
     response = client.get('/api/v1/cities')
 
@@ -13,7 +13,8 @@ def test_get_cities(client, init_testdb, insert_data_db):
 
     assert response.status_code == 200
     assert len(data) == 11
-    assert isinstance(data['Amsterdam'], int)
+    assert data[0][0] == 'Rotterdam'
+    # assert isinstance(data['Amsterdam'], int)
 
 
 def test_get_cities_city_like(client, init_testdb, insert_data_db):
@@ -27,5 +28,5 @@ def test_get_cities_city_like(client, init_testdb, insert_data_db):
 
     assert response.status_code == 200
     assert len(data) == 2
-    assert isinstance(data['Amsterdam'], int)
-    assert isinstance(data['Rotterdam'], int)
+    assert data[0][0] == 'Rotterdam'
+    assert data[1][0] == 'Amsterdam'

--- a/tests/functional/test_get_cities.py
+++ b/tests/functional/test_get_cities.py
@@ -1,0 +1,29 @@
+from flask import json
+
+
+def test_get_cities(client, init_testdb, insert_data_db):
+    '''
+    GIVEN that there are more than 15 companies in the DB
+    WHEN the '/api/v1/cities' page is requested (GET)
+    THEN the response will contain a dict of all the city records (key) and the count (value) of companies in those cities
+    '''
+    response = client.get('/api/v1/cities')
+
+    data = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 200
+    assert len(data) == 11
+    assert isinstance(data['Amsterdam'], int)
+
+
+def test_get_cities_city_like(client, init_testdb, insert_data_db):
+    '''
+    GIVEN that Rotterdam and Amsterdam are in the cities DB 
+    WHEN the '/api/v1/cities is requested with a city_like=Dam parameter
+    THEN the response will contain 2 records and their associated data
+    '''
+    response = client.get('/api/v1/cities?city_like=Dam')
+    data = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 200
+    assert len(data) == 2


### PR DESCRIPTION
## What?
An API endpoint was created to provide a list of cities from the DB where companies are located, with a count how many companies can be found in that city.

## Why?
The frontend uses an autocomplete list when searching for companies in a specific city. This list provides a list of cities that match the search string with a count of the number of companies in those specific cities.

## How?
I could not find a way to query the DB with an SQLAlchemy ORM query, so ended up doing this with raw SQL. Created a query for all cities and a query with a city_like parameter to query for specific search strings, when this parameter is present in the GET url. 

## Testing?
Added 2 tests to check if the cities endpoint and cities endpoint with a city_like parameter returned the expected results. Both tests passed.

## Anything else?
Using raw SQL might expose us to SQL injection attacks. However, I think I implemented it in such a way, by using parameterized queries, that this risk is currenty minimized. 

@Reinoptland, could you please advise whether these parameterized raw SQL queries are safe enough to protect us from SQL Injection attacks? 