### PR TITLE
Feature/api patch company endpoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,5 +57,6 @@ jobs:
           REDIS_URL: ${{ secrets.REDIS_URL }}
           CACHE_DEFAULT_TIMEOUT: ${{ secrets.CACHE_DEFAULT_TIMEOUT }}
           CACHE_REDIS_PASSWORD: ${{ secrets.CACHE_REDIS_PASSWORD }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
           
 

--- a/app/api/companies.py
+++ b/app/api/companies.py
@@ -1,4 +1,3 @@
-from asyncio import exceptions
 from app import db, cache
 from app.api import bp
 from app.api.errors import bad_request, error_response
@@ -7,7 +6,6 @@ from app.import_data_v2 import insert_meta, insert_city
 from flask import jsonify, request, url_for
 from flask_jwt_extended import create_access_token, jwt_required
 from marshmallow import ValidationError
-import pdb
 
 
 # TODO: Looking into errors, validation and bad requests
@@ -182,43 +180,41 @@ def add_company():
     return response
 
 
-# TODO: Create a specific error message when selecting a non-existing company_id
 @bp.route('/v1/companies/<int:id>', methods=['PATCH'])
 @jwt_required()
 def update_company(id):
+    company = Companies.query.get_or_404(id)
 
     data = request.get_json() or {}
 
     try:
-        result = CompaniesPatchSchema().load(data, partial=True)
+        validated_data = CompaniesPatchSchema().load(data, partial=True)
     except ValidationError as err:
         return bad_request(err.messages)
 
-    exceptions = ['city_name', 'disciplines', 'branches', 'tags']
-    for field in exceptions:
-        if field in data:
+    fields_in_related_tables = ['city_name', 'disciplines', 'branches', 'tags']
+    for field in fields_in_related_tables:
+        if field in validated_data:
             if field == 'city_name':
-                city_dict = insert_city(data)
-                data['city_id'] = city_dict['city_id']
-                data.pop('city_name')
-                data.pop('region')
+                city_dict = insert_city(validated_data)
+                validated_data['city_id'] = city_dict['city_id']
+                validated_data.pop('city_name')
             if field in ['disciplines', 'branches', 'tags']:
                 # TODO: Only removes the records from the companies_meta table, not the actual records in the Meta table (as these could still be in use by other companies)
+                # RAW SQL statement for finding orphaned meta records: "SELECT * FROM Meta WHERE meta_id NOT IN (SELECT meta_id FROM companies_meta);"
                 db.session.execute("DELETE FROM companies_meta WHERE companies_meta.company_id = :id AND companies_meta.meta_id IN (SELECT Meta.meta_id FROM Meta WHERE Meta.type = :type)", {
                                    "id": id, "type": field})
 
                 # Adds the meta data:
-                insert_meta(data[field], field, id)
-                data.pop(field)
+                insert_meta(validated_data[field], field, id)
+                validated_data.pop(field)
 
     # Make the update in the DB
-    if data:
-        Companies.query.filter_by(company_id=id).update(data)
-        db.session.commit()
+    for field in validated_data:
+        setattr(company, field, validated_data[field])
+    db.session.commit()
 
     # Create response
-    company = Companies.query.filter_by(company_id=id).first()
-
     response = jsonify(company.to_dict())
     response.status_code = 200
     response.headers['Location'] = url_for('api.get_company', id=id)

--- a/app/import_data_v2.py
+++ b/app/import_data_v2.py
@@ -10,39 +10,42 @@ import_data('db.json')
 '''
 
 
+def insert_meta(input, type, company_id):
+    if input is not None:
+        # Iterate over the meta type
+        for item in input:
+
+            # Check if the meta string is already in the Meta table
+            item_check = Meta.query.filter_by(
+                type=type, meta_string=item).first()
+
+            # Add the meta string if not in Meta table
+            if item_check is None:
+                item_input = Meta(type=type, meta_string=item)
+                db.session.add(item_input)
+                db.session.commit()
+
+                # Query the newly added meta string from the Meta table
+                item_check = item_input
+
+            # Get the meta_id for the companies_meta table if the meta string was already in the table or just added to the table
+            meta_id = item_check.meta_id
+
+            # Add the company_id and meta_id to the companies_meta table
+            try:
+                meta_input = f'INSERT INTO companies_meta (meta_id, company_id) VALUES ({meta_id}, {company_id}) ON CONFLICT DO NOTHING'
+                db.session.execute(meta_input)
+                db.session.commit()
+            except:
+                print(
+                    f"Company ID ({company_id}) has duplicate meta ({meta_id})")
+    return
+
 # Function to insert meta data
 # Example insert_meta(agency['disciplines'], 'disciplines', company_id)
+
+
 def import_data(import_file):
-    def insert_meta(input, type, company_id):
-        if input is not None:
-            # Iterate over the meta type
-            for item in input:
-
-                # Check if the meta string is already in the Meta table
-                item_check = Meta.query.filter_by(
-                    type=type, meta_string=item).first()
-
-                # Add the meta string if not in Meta table
-                if item_check is None:
-                    item_input = Meta(type=type, meta_string=item)
-                    db.session.add(item_input)
-                    db.session.commit()
-
-                    # Query the newly added meta string from the Meta table
-                    item_check = item_input
-
-                # Get the meta_id for the companies_meta table if the meta string was already in the table or just added to the table
-                meta_id = item_check.meta_id
-
-                # Add the company_id and meta_id to the companies_meta table
-                try:
-                    meta_input = f'INSERT INTO companies_meta (meta_id, company_id) VALUES ({meta_id}, {company_id}) ON CONFLICT DO NOTHING'
-                    db.session.execute(meta_input)
-                    db.session.commit()
-                except:
-                    print(
-                        f"Company ID ({company_id}) has duplicate meta ({meta_id})")
-        return
 
     # Opening JSON file
     with open(import_file) as file:

--- a/app/import_data_v2.py
+++ b/app/import_data_v2.py
@@ -73,12 +73,12 @@ def import_data(import_file):
                 company_size = '1-10'
 
             # Check if the city is already in the cities dict
-            if agency['city'].capitalize() not in cities.values():
+            if agency['city'].title() not in cities.values():
 
                 # If city is not in the cities dict, add the city and company to the DB
                 city_insert = Cities(
-                    city_name=agency['city'].capitalize(), region=region)
-                company_insert = Companies(company_name=agency['name'], logo_image_src=agency['eguideImageSrc'],
+                    city_name=agency['city'].title(), region=region)
+                company_insert = Companies(company_name=agency['name'].title(), logo_image_src=agency['eguideImageSrc'],
                                            website=agency['website'], year=agency['yearEstablished'], company_size=company_size)
                 city_insert.company.append(company_insert)
                 db.session.add(city_insert)
@@ -91,10 +91,10 @@ def import_data(import_file):
             else:
                 # Get the city_id
                 city_id = [k for k, v in cities.items() if v ==
-                           agency['city'].capitalize()][0]
+                           agency['city'].title()][0]
 
                 # Insert the company into the DB
-                company_insert = Companies(company_name=agency['name'], logo_image_src=agency['eguideImageSrc'], city_id=city_id,
+                company_insert = Companies(company_name=agency['name'].title(), logo_image_src=agency['eguideImageSrc'], city_id=city_id,
                                            website=agency['website'], year=agency['yearEstablished'], company_size=company_size)
                 db.session.add(company_insert)
                 db.session.commit()

--- a/app/import_data_v2.py
+++ b/app/import_data_v2.py
@@ -11,6 +11,10 @@ import_data('db.json')
 
 
 def insert_meta(input, type, company_id):
+    '''
+    Function to insert meta data
+    Example insert_meta(agency['disciplines'], 'disciplines', company_id)
+    '''
     if input is not None:
         # Iterate over the meta type
         for item in input:
@@ -41,8 +45,32 @@ def insert_meta(input, type, company_id):
                     f"Company ID ({company_id}) has duplicate meta ({meta_id})")
     return
 
-# Function to insert meta data
-# Example insert_meta(agency['disciplines'], 'disciplines', company_id)
+
+def insert_city(dict):
+    '''
+
+    '''
+    # Query if city is already in DB
+    query = Cities.query.filter_by(city_name=dict['city_name'].title()).first()
+    result = {}
+
+    if query is not None:
+        result['city_id'] = query.city_id
+    else:
+        regions = ['Remote', 'Drenthe', 'Flevoland', 'Friesland', 'Gelderland', 'Groningen', 'Limburg',
+                   'Noord-Brabant', 'Noord-Holland', 'Overijssel', 'Utrecht', 'Zuid-Holland', 'Zeeland']
+        if 'region' not in dict or dict['region'] not in regions:
+            dict['region'] = 'Remote'
+
+        new_city = Cities(
+            city_name=dict['city_name'].title(), region=dict['region'])
+
+        db.session.add(new_city)
+        db.session.commit()
+        result['city_id'] = new_city.city_id
+        result['region'] = new_city.region
+
+    return result
 
 
 def import_data(import_file):

--- a/app/models.py
+++ b/app/models.py
@@ -106,17 +106,6 @@ class Companies(PaginationAPIMixin, db.Model):
             'branches': []
         }
 
-        # if self.city_name is not None:
-        #     data['city_name'] = self.city_name
-        # else:
-        #     data['city_name'] = ''
-
-        # if self.city.region.value is not None:
-        #     data['region'] = self.city.region.value
-        # else:
-        #     data['region'] = 'Unknown'
-
-        # Iterating over all the meta id's to fill the discipline/tags/branches lists
         for meta in self.metas:
             if meta.type == 'disciplines':
                 data['disciplines'].append(meta.meta_string)
@@ -125,97 +114,6 @@ class Companies(PaginationAPIMixin, db.Model):
             elif meta.type == 'branches':
                 data['branches'].append(meta.meta_string)
         return data
-
-    def from_dict(self, data, new_company=False):
-        # TODO:
-        # Check if city is already in Cities table, otherwise add it
-        # If new company, add meta input
-        # If existing company, remove old meta input, check if meta input already exists in Meta db, otherwise add it
-        # Add company information
-        pass
-
-    def from_dict_new(self, data):
-
-        # Add Companies fields
-        for field in ['company_name', 'logo_image_src', 'website', 'year', 'company_size']:
-            if field in data:
-                setattr(self, field, data[field])
-            else:
-                if field == 'company_size':
-                    setattr(self, field, 'Unknown')
-                else:
-                    setattr(self, field, '')
-
-        # TODO: method / endpoint still breaks if not all data fields are supplied
-        # Check if city is already in Cities table
-        if 'city_name' in data:
-            city = Cities.query.filter_by(city_name=data['city_name']).first()
-            if city is None:
-                if 'region' in data:
-                    region = data['region']
-                else:
-                    region = 'Unknown'
-                new_city = Cities(city_name=data['city_name'], region=region)
-                new_city.company.append(self)
-            else:
-                setattr(self, 'city_id', city.city_id)
-        # else:
-            # setattr(self, 'city_id', '')
-            # self.city_name = ''
-            # self.city.region = 'Unknown'
-
-            # Check if the disciplines, branches, tags already in Meta table, otherwise add it
-        for field in ['disciplines', 'branches', 'tags']:
-            if field in data:
-                for item in data[field]:
-                    # Lookup if item is already in Meta table
-                    meta = Meta.query.filter_by(
-                        meta_string=item, type=field).first()
-                    if meta == 1:
-                        self.metas.append(meta)
-                    # If not in table add it:
-                    else:
-                        new_meta = Meta(meta_string=item, type=field)
-                        self.metas.append(new_meta)
-            else:
-                setattr(self, field, '')
-
-        return self
-
-    def from_dict_adjust(self, data):
-        # Check if city is already in Cities table, otherwise add it
-        if 'city_name' in data:
-            # Check if city is already in Cities table
-            city = Cities.query.filter_by(city_name=data['city_name']).first()
-
-            # If city not in Cities table, add it
-            if city == 0:
-                new_city = Cities(
-                    city_name=data['city_name'], region=data['region'])
-                self.city.append(new_city)
-            # If city in Cities table, change the city_id in the Companies table
-            else:
-                setattr(self, 'city_id', city.city_id)
-
-        # Check if the disciplines, branches, tags already in Meta table, otherwise add it
-        # TODO:
-        for field in ['disciplines', 'branches', 'tags']:
-            if field in data:
-                for item in data[field]:
-                    # Also remove the previous records in the database self.metas.remove(...)?
-                    # Lookup if item is already in Meta table
-                    meta = Meta.query.filter_by(
-                        meta_string=item, type=field).first()
-                    if meta == 1:
-                        self.metas.append(meta)
-                    # If not in table add it:
-                    else:
-                        new_meta = Meta(meta_string=item, type=field)
-                        self.metas.append(new_meta)
-        # Add Companies fields
-        for field in ['company_name', 'logo_image_src', 'website', 'year', 'company_size']:
-            if field in data:
-                setattr(self, field, data[field])
 
 
 class Cities(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -5,9 +5,8 @@ from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 from marshmallow import validate, ValidationError, pre_load, post_load
 
+
 # Pagination mixin Class
-
-
 class PaginationAPIMixin(object):
     @staticmethod
     def to_collection_dict(query, page, per_page, endpoint, **kwargs):
@@ -234,13 +233,14 @@ class CompaniesPatchSchema(ma.SQLAlchemySchema):
     year = ma.Int(validate=validate.Range(min=1890, max=datetime.now().year))
     company_size = ma.Str(validate=validate.OneOf(
         sizes), required=True)
-    disciplines = ma.List(ma.Str(validate=validate.Length(min=2, max=120)))
+    disciplines = ma.List(
+        ma.Str(validate=validate.Length(min=2, max=120)))
     branches = ma.List(ma.Str(validate=validate.Length(min=2, max=120)))
     tags = ma.List(ma.Str(validate=validate.Length(min=2, max=120)))
 
     # Additional Validation check
     @post_load
-    def check_company_name(self, data, **kwargs):
+    def company_name_exists(self, data, **kwargs):
         if 'company_name' in data:
             company = Companies.query.filter_by(
                 company_name=data['company_name'].title()).first()
@@ -248,3 +248,4 @@ class CompaniesPatchSchema(ma.SQLAlchemySchema):
                 raise ValidationError(
                     "A company already exists with this company_name. Please use a different company_name.")
             return data
+        return data

--- a/config.py
+++ b/config.py
@@ -135,7 +135,7 @@ class TestConfig(Config):
 
     # SQLAlchemy settings
     SQLALCHEMY_DATABASE_URI = TESTING_DB_URL
-    SQLALCHEMY_ECHO = True
+    SQLALCHEMY_ECHO = False
 
     # Cache Redis DB settings
     CACHE_TYPE = os.environ['CACHE_TYPE']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
-from app.models import Users
-import pytest
 from app import create_app, db
 from app.import_data_v2 import import_data
-from flask_login import login_user
+from app.models import Users
 from config import TestConfig
+from flask import json
+from flask_login import login_user
+import pytest
 
 
 @pytest.fixture(scope='module')
@@ -21,7 +22,7 @@ def client():
 
 
 @pytest.fixture(scope='module')
-def init_testdb(client):
+def init_testdb():
     # Create the database
     db.create_all()
 
@@ -34,12 +35,12 @@ def init_testdb(client):
 
 
 @pytest.fixture(scope='module')
-def insert_data_db(client, init_testdb):
+def insert_data_db(init_testdb):
     import_data('test_db.json')
 
 
 @pytest.fixture(scope='module')
-def new_user(client, init_testdb):
+def new_user(init_testdb):
     new_user = Users(username='Test User', email='test@fnder-backend.com')
     new_user.set_password('testtest')
 
@@ -47,6 +48,25 @@ def new_user(client, init_testdb):
     db.session.commit()
 
     return new_user
+
+
+# TODO: How to use the token in other tests?
+@pytest.fixture(scope='module')
+def get_token(client, init_testdb, new_user):
+
+    data = {
+        "username": "Test User",
+        "password": "testtest"
+    }
+
+    response = client.post("/api/v1/token", data=json.dumps(data),
+                           headers={"Content-Type": "application/json"},)
+
+    result = json.loads(response.get_data(as_text=True))
+
+    token = result['token']
+
+    return token
 
 
 @pytest.fixture(scope='module')

--- a/tests/functional/test_get_token.py
+++ b/tests/functional/test_get_token.py
@@ -4,8 +4,8 @@ from flask import json
 def test_get_token(client, new_user):
     '''
     GIVEN a Flask application configured for testing
-    WHEN a POST request is made to /api/v1/companies with a valid company
-    THEN check that the response is valid and particular data can be found
+    WHEN a POST request is made to /api/v1/token with valid user credentials
+    THEN check that a token is returned
     '''
 
     data = {
@@ -17,6 +17,27 @@ def test_get_token(client, new_user):
                            headers={"Content-Type": "application/json"},)
 
     result = json.loads(response.get_data(as_text=True))
-    print(result)
+
     assert response.status_code == 200
     assert result['token'] is not None
+
+
+def test_get_token_invalid(client, new_user):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a POST request is made to /api/v1/token with invalid user credentials
+    THEN check that the response is unauthorized and correct error message is shown
+    '''
+
+    data = {
+        "username": "Not existing User",
+        "password": "testtest"
+    }
+
+    response = client.post("/api/v1/token", data=json.dumps(data),
+                           headers={"Content-Type": "application/json"},)
+
+    result = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 401
+    assert result['message'] == 'Invalid user credentials'

--- a/tests/functional/test_get_token.py
+++ b/tests/functional/test_get_token.py
@@ -1,0 +1,22 @@
+from flask import json
+
+
+def test_get_token(client, new_user):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a POST request is made to /api/v1/companies with a valid company
+    THEN check that the response is valid and particular data can be found
+    '''
+
+    data = {
+        "username": "Test User",
+        "password": "testtest"
+    }
+
+    response = client.post("/api/v1/token", data=json.dumps(data),
+                           headers={"Content-Type": "application/json"},)
+
+    result = json.loads(response.get_data(as_text=True))
+    print(result)
+    assert response.status_code == 200
+    assert result['token'] is not None

--- a/tests/functional/test_patch_company.py
+++ b/tests/functional/test_patch_company.py
@@ -47,32 +47,38 @@ def test_patch_valid_company(client, get_token, insert_data_db):
     assert result['year'] == 1969
 
 
-def test_patch_invalid_company(client, insert_data_db, get_token):
+def test_patch_invalid_company_name(client, get_token):
     '''
     GIVEN a Flask application configured for testing
-    WHEN a PATCH request is made to /api/v1/companies/2 with a invalid company
+    WHEN a PATCH request is made to /api/v1/companies/2 with an already existing company_name
     THEN check that the response is invalid and particular error messages can be found
     '''
-
     # Create dict for invalid patch request with an already existing company_name
-    data1 = {
+    data = {
         "company_name": "H1 Webdevelopment"
     }
 
-    response1 = client.patch('/api/v1/companies/2', data=json.dumps(data1),
-                             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
-    result1 = json.loads(response1.get_data(as_text=True))
+    response = client.patch('/api/v1/companies/2', data=json.dumps(data),
+                            headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result = json.loads(response.get_data(as_text=True))
 
-    # Create dict for invalid patch request with an company_id and region
-    data2 = {
+    assert result['message']['_schema'][0] == "A company already exists with this company_name. Please use a different company_name."
+
+
+def test_patch_invalid_company_fields(client, get_token):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a PATCH request is made to /api/v1/companies/2 with a company_id and region field
+    THEN check that the response is invalid and particular error messages can be found
+    '''
+    data = {
         "region": "Friesland",
         "company_id": 22
     }
 
-    response2 = client.patch('/api/v1/companies/2', data=json.dumps(data2),
-                             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
-    result2 = json.loads(response2.get_data(as_text=True))
+    response = client.patch('/api/v1/companies/2', data=json.dumps(data),
+                            headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result = json.loads(response.get_data(as_text=True))
 
-    assert result1['message']['_schema'][0] == "A company already exists with this company_name. Please use a different company_name."
-    assert result2['message']['region'][0] == "Unknown field."
-    assert result2['message']['company_id'][0] == "Unknown field."
+    assert result['message']['region'][0] == "Unknown field."
+    assert result['message']['company_id'][0] == "Unknown field."

--- a/tests/functional/test_patch_company.py
+++ b/tests/functional/test_patch_company.py
@@ -1,0 +1,78 @@
+from flask import json
+
+
+def test_patch_valid_company(client, get_token, insert_data_db):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a PATCH request is made to /api/v1/companies/1 with a valid patch information
+    THEN check that the response is valid and particular data can be found
+    '''
+    data = {
+        "branches": [
+            "Nog niet bestaande branche",
+            "Nog niet bestaande branche #3"
+
+        ],
+        "city_name": "Lutjebroek",
+        "company_name": "Test company #1000",
+        "company_size": "GT-100",
+        "disciplines": [
+            "Nog niet bestaande discipline",
+            "Nog niet bestaande discipline #2"
+        ],
+        "logo_image_src": "https://www.nos.nl/",
+        "tags": [
+            "Nog niet bestaande tag",
+            "Nog niet bestaande tag #2"
+        ],
+        "website": "https://www.google.com/",
+        "year": 1969
+    }
+
+    response = client.patch('/api/v1/companies/1', data=json.dumps(data),
+                            headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+
+    result = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 200
+    assert result['company_id'] == 1
+    assert result['company_name'] == 'Test company #1000'
+    assert result['city_name'] == 'Lutjebroek'
+    assert result['region'] == 'Remote'
+    assert result['company_size'] == 'GT-100'
+    assert result['branches'][0] == 'Nog niet bestaande branche'
+    assert result['disciplines'][0] == 'Nog niet bestaande discipline'
+    assert result['tags'][0] == 'Nog niet bestaande tag'
+    assert result['website'] == 'https://www.google.com/'
+    assert result['year'] == 1969
+
+
+def test_patch_invalid_company(client, insert_data_db, get_token):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a PATCH request is made to /api/v1/companies/2 with a invalid company
+    THEN check that the response is invalid and particular error messages can be found
+    '''
+
+    # Create dict for invalid patch request with an already existing company_name
+    data1 = {
+        "company_name": "H1 Webdevelopment"
+    }
+
+    response1 = client.patch('/api/v1/companies/2', data=json.dumps(data1),
+                             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result1 = json.loads(response1.get_data(as_text=True))
+
+    # Create dict for invalid patch request with an company_id and region
+    data2 = {
+        "region": "Friesland",
+        "company_id": 22
+    }
+
+    response2 = client.patch('/api/v1/companies/2', data=json.dumps(data2),
+                             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result2 = json.loads(response2.get_data(as_text=True))
+
+    assert result1['message']['_schema'][0] == "A company already exists with this company_name. Please use a different company_name."
+    assert result2['message']['region'][0] == "Unknown field."
+    assert result2['message']['company_id'][0] == "Unknown field."

--- a/tests/functional/test_post_company.py
+++ b/tests/functional/test_post_company.py
@@ -1,0 +1,114 @@
+from flask import json
+
+
+def test_post_valid_company(client, get_token):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a POST request is made to /api/v1/companies with a valid company
+    THEN check that the response is valid and particular data can be found
+    '''
+    data = {
+        "branches": [
+            "Nog niet bestaande branche"
+        ],
+        "city_name": "Lutjebroek",
+        "company_name": "Test company #999",
+        "company_size": "11-50",
+        "disciplines": [
+            "Conceptontwikkeling",
+            "Conversie-optimalisatie",
+            "Strategie",
+            "Nog niet bestaande discipline",
+            "Nog niet bestaande discipline #2"
+        ],
+        "logo_image_src": "https://www.nos.nl/",
+        "region": "Remote",
+        "tags": [
+            "Angular",
+            "App-bouwer",
+            "Nog niet bestaande tag",
+            "Nog niet bestaande tag #2"
+        ],
+        "website": "https://www.google.com/",
+        "year": 1969
+    }
+
+    response = client.post('/api/v1/companies', data=json.dumps(data),
+                           headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+
+    result = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 201
+    assert result['company_id'] == 1
+    assert result['company_name'] == 'Test company #999'
+    assert result['city_name'] == 'Lutjebroek'
+    assert result['region'] == 'Remote'
+    assert result['company_size'] == '11-50'
+    assert result['branches'][0] == 'Nog niet bestaande branche'
+    assert result['website'] == 'https://www.google.com/'
+    assert result['year'] == 1969
+
+
+def test_post_invalid_company(client, insert_data_db, get_token):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a POST request is made to /api/v1/companies with a invalid company
+    THEN check that the response is invalid and particular error messages can be found
+    '''
+    data = {
+        "branches": [
+            "Nog niet bestaande branche"
+        ],
+        "city_name": "Lutjebroek",
+        "company_name": "Test company #999",
+        "company_size": "11-50",
+        "disciplines": [
+            "Conceptontwikkeling",
+            "Conversie-optimalisatie",
+            "Strategie",
+            "Nog niet bestaande discipline",
+            "Nog niet bestaande discipline #2"
+        ],
+        "logo_image_src": "https://www.nos.nl/",
+        "region": "Remote",
+        "tags": [
+            "Angular",
+            "App-bouwer",
+            "Nog niet bestaande tag",
+            "Nog niet bestaande tag #2"
+        ],
+        "website": "https://www.google.com/",
+        "year": 1969
+    }
+
+    # Create dictionary with invalid company including company_id
+    data1 = data.copy()
+    data1['company_id'] = 21
+
+    response1 = client.post('/api/v1/companies', data=json.dumps(data1),
+                            headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result1 = json.loads(response1.get_data(as_text=True))
+
+    # Create dictionary with invalid company with company_name already in DB
+    data2 = data.copy()
+    data2['company_name'] = 'daily dialogues (Part of CANDID)'
+
+    response2 = client.post('/api/v1/companies', data=json.dumps(data2),
+                            headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result2 = json.loads(response2.get_data(as_text=True))
+
+    # Create dictionary with invalid company missing required fields:
+    data3 = data.copy()
+    for x in ['company_size', 'website', 'company_name', 'city_name']:
+        data3.pop(x)
+
+    response3 = client.post('/api/v1/companies', data=json.dumps(data3),
+                            headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result3 = json.loads(response3.get_data(as_text=True))
+
+    assert result1['message']['_schema'][0] == "Create new company cannot include company_id. For modifying existing companies please use the PATCH method"
+    assert result2['message']['_schema'][0] == "A company already exists with this company_name. Please use the PATCH method if you would like to modify this company or use a different company_name if you would like to add a different company."
+    assert result3['message']['city_name'][0] == "Missing data for required field."
+    assert result3['message']['company_name'][0] == "Missing data for required field."
+    assert result3['message']['company_size'][0] == "Missing data for required field."
+    assert result3['message']['website'][0] == "Missing data for required field."


### PR DESCRIPTION
## What?
Finished the API endpoint to update an existing company and make the changes into the DB using a PATCH request with a JWT token.

## Why?
This way, existing companies can be updated by users from the frontend to make the FNDR app more relevant and up-to-date.

## How?
An API endpoint was created and protected by JWT Tokens. The data provided by the user via a PATCH request is validated with a CompaniesPatchSchema using Flask-Marshmallow. Additional validation and processing was added to make sure new cities and meta data were handled correctly.

## Testing?
Tests were added to check if the correct responses were returned by making a PATCH request with valid details and also if the validation validated properly and the correct error messages were returned when providing invalid details. All tests were passed.

## Anything else?
For changing the meta data, at first the meta data will be removed from the companies_meta table, after which the new data will be added. For this I have used a raw SQL statement, but without any user input involved. No records from the Meta table will be removed, as it is possible these records are still in use by other companies. However, this might lead to a growing Meta table as unused records are also not removed from this table.

@Reinoptland , let's discuss if we find this acceptable?