### PR TITLE
Bugfix for optional fields in POST request, including tests

### DIFF
--- a/app/api/companies.py
+++ b/app/api/companies.py
@@ -191,20 +191,24 @@ def add_company():
 
     # Check if city is already in DB:
     city = Cities()
-    city_id = city.get_or_create(
-        validated_data['city_name'], validated_data['region'])
+    validated_data['city_id'] = city.get_or_create(validated_data)
 
-    new_company = Companies(company_name=validated_data['company_name'], logo_image_src=validated_data['logo_image_src'],
-                            website=validated_data['website'], year=validated_data['year'], company_size=validated_data['company_size'], city_id=city_id)
+    # Create new company
+    new_company = Companies()
+    fields = ['company_name', 'logo_image_src',
+              'website', 'year', 'company_size', 'city_id']
+    for field in fields:
+        if field in validated_data:
+            setattr(new_company, field, validated_data[field])
 
     db.session.add(new_company)
     db.session.commit()
 
     # Insert Meta Data:
-    insert_meta(validated_data['disciplines'],
-                'disciplines', new_company.company_id)
-    insert_meta(validated_data['branches'], 'branches', new_company.company_id)
-    insert_meta(validated_data['tags'], 'tags', new_company.company_id)
+    meta = ['disciplines', 'branches', 'tags']
+    for field in meta:
+        if field in validated_data:
+            insert_meta(validated_data[field], field, new_company.company_id)
 
     # Create response
     response = jsonify(new_company.to_dict())

--- a/app/models.py
+++ b/app/models.py
@@ -134,10 +134,14 @@ class Cities(db.Model):
     def __repr__(self):
         return '<City ID: {}>'.format(self.city_id)
 
-    def get_or_create(self, city, region):
-        query = Cities.query.filter_by(city_name=city.title()).first()
+    def get_or_create(self, dict):
+        query = Cities.query.filter_by(
+            city_name=dict['city_name'].title()).first()
         if query is None:
-            new_city = Cities(city_name=city.title(), region=region)
+            if 'region' not in dict:
+                dict['region'] = 'Remote'
+            new_city = Cities(
+                city_name=dict['city_name'].title(), region=dict['region'])
             db.session.add(new_city)
             db.session.commit()
             setattr(self, 'city_id', new_city.city_id)

--- a/tests/functional/test_post_company.py
+++ b/tests/functional/test_post_company.py
@@ -49,6 +49,31 @@ def test_post_valid_company(client, get_token):
     assert result['year'] == 1969
 
 
+def test_post_valid_company_optional_fields(client, get_token):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a POST request is made to /api/v1/companies with a valid company missing some optional fields
+    THEN check that the response is valid and particular data can be found
+    '''
+    data = {
+        "city_name": "Hoorn",
+        "company_name": "Test company #777",
+        "company_size": "GT-100",
+        "website": "https://testdetest.nl"
+    }
+
+    response = client.post('/api/v1/companies', data=json.dumps(data),
+                           headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 201
+    assert result['company_id'] == 2
+    assert result['company_name'] == 'Test company #777'
+    assert result['city_name'] == 'Hoorn'
+    assert result['company_size'] == 'GT-100'
+    assert result['website'] == 'https://testdetest.nl'
+
+
 def test_post_invalid_company_id(client, insert_data_db, get_token):
     '''
     GIVEN a Flask application configured for testing


### PR DESCRIPTION
## What?
When creating a new company with a POST request to /api/v1/companies, with only providing the required fields, this returns a 500 error.

## Why?
Due to this bug it was not possible to create a company without supplying all the optional fields.

## How?
Changed the create_company() to only add the present fields in the validated_data to the Company object. This function was previously trying to add all the fields to the object, even those which weren't supplied by the user.

## Testing?
Added a test which checks if the responses is valid when optional fields are missing.

## Anything else?
Nothing.