### PR TITLE
Bugfix/patch_company_validation

### DIFF
--- a/app/api/companies.py
+++ b/app/api/companies.py
@@ -226,6 +226,7 @@ def update_company(id):
     company = Companies.query.get_or_404(id)
 
     data = request.get_json() or {}
+    data['id_for_check_company'] = company.company_id
 
     try:
         validated_data = CompaniesPatchSchema().load(data, partial=True)

--- a/tests/functional/test_patch_company.py
+++ b/tests/functional/test_patch_company.py
@@ -82,3 +82,24 @@ def test_patch_invalid_company_fields(client, get_token):
 
     assert result['message']['region'][0] == "Unknown field."
     assert result['message']['company_id'][0] == "Unknown field."
+
+
+def test_patch_company_name_unchanged(client, get_token):
+    '''
+    GIVEN a Flask application configured for testing
+    WHEN a PATCH request is made to /api/v1/companies/2 with an unchanged company_name field and valid other field
+    THEN check that the response is valid and specific data can be found
+    '''
+    data = {
+        "company_name": "Test company #1000",
+        "year": 2000
+    }
+
+    response = client.patch('/api/v1/companies/1', data=json.dumps(data),
+                            headers={'Content-Type': 'application/json', 'Authorization': 'Bearer {}'.format(get_token)},)
+    result = json.loads(response.get_data(as_text=True))
+
+    assert response.status_code == 200
+    assert result['company_id'] == 1
+    assert result['company_name'] == 'Test company #1000'
+    assert result['year'] == 2000


### PR DESCRIPTION
## What?
Bugfix for error that arises when an unchanged company_name is in the PATCH request, saying that the company_Name already exists. 

## Why?
The validation that checks if the company_name already exists in the DB does not exclude the record it is currently updating. 

## How?
Added a check to the validation for whether the company_name already exits that checks if the company_name is currently in use by the current record.

## Testing?
Added a test to copy the issue that had arisen. All tests pass with the bugfix.

## Anything else?
Nothing.